### PR TITLE
Modified RPM Limits Patch

### DIFF
--- a/8AA991B0.pnach
+++ b/8AA991B0.pnach
@@ -318,8 +318,6 @@ author=Ooper
 description=Returns Kerbs back to normal.
 patch=1,EE,21FF1D4C,extended,3fa70a3c
 
-gametitle=Gran Turismo 3 [PBPX_955.03;1]NTSC [8AA991B0]
-
 //0350AF0 unused byte used for conditional execution
 //Main Menu Byte 1FFF1A4. Sets all values to safe values when it is 1. It is 1 before selecting an event and in main menu, so it will always reset values going from sim to arcade.
 //Single race ticks 1F978FC

--- a/8AA991B0.pnach
+++ b/8AA991B0.pnach
@@ -312,35 +312,122 @@ patch=1,EE,D1FF2934,extended,02000001
 patch=1,EE,21FF1830,extended,3fa70a3c
 patch=1,EE,21FF1D4C,extended,3fa70a3c
 
-
 [License Tests\Normal Kerbs]
 author=Ooper
 description=Returns Kerbs back to normal.
 patch=1,EE,21FF1D4C,extended,3fa70a3c
 
-//if single race ticks hit 1
-//set our test byte to 1
-//if championship tick hits 1
-//set our test byte to 2
-//if byte is 1(single race) else skip 2 lines
-//set max rpm to 17000
-//set rpm redline to 17000
-//if byte is 2(Championship race) else skip 2 lines
-//set max rpm to 17000
-//set rpm redline to 17000
-[RPM Limits\Simulation Mode\Give Player 17000RPM Limit On All Cars]
-author=Ooper
-description=Change player's car max RPM Limit to 17000, single, championship, endurance races.
+//0350AF0 unused byte used for conditional execution
+//Single race ticks 1F978FC
+//Championship race ticks 1F9685C
+//License test ticks 1FD0D0C
+//Machine test ticks 1FB728C
+//Home -> test run ticks 1FC55BC
+//Arcade Race Ticks 1FAC35C
+//Time Trial Ticks 1FBB6B0
+[RPM Limits\17000 RPM]
+author=Ooper,DopplerEffect
+description=Player Car Max RPM 17000
+//race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial
 patch=1,EE,D1F978FC,extended,01000001
 patch=1,EE,00350AF0,extended,00000001
 patch=1,EE,D1F9685C,extended,01000001
 patch=1,EE,00350AF0,extended,00000002
+patch=1,EE,D1FD0D0C,extended,01000001
+patch=1,EE,00350AF0,extended,00000003
+patch=1,EE,D1FB728C,extended,01000001
+patch=1,EE,00350AF0,extended,00000004
+patch=1,EE,D1FC55BC,extended,01000001
+patch=1,EE,00350AF0,extended,00000005
+patch=1,EE,D1FAC35C,extended,01000001
+patch=1,EE,00350AF0,extended,00000006
+patch=1,EE,D1FBB6B0,extended,01000100
+patch=1,EE,00350AF0,extended,00000007
+//sets rev limit to 17000 and redline to 15000
+//sim single race
 patch=1,EE,D0350AF0,extended,02000001
 patch=1,EE,11FBDAB0,extended,00004268
-patch=1,EE,11FBDB12,extended,00004268
+patch=1,EE,11FBDB12,extended,00003A98
+//sim championship race
 patch=1,EE,D0350AF0,extended,02000002
 patch=1,EE,11FBCA6C,extended,00004268
+patch=1,EE,11FBCACE,extended,00003A98
+//sim license test
+patch=1,EE,D0350AF0,extended,02000003
+patch=1,EE,11FF1650,extended,00004268
+patch=1,EE,11FF16B2,extended,00003A98
+//sim machine test
+patch=1,EE,D0350AF0,extended,02000004
+patch=1,EE,11FF1900,extended,00004268
+patch=1,EE,11FF1962,extended,00003A98
+//sim test run
+patch=1,EE,D0350AF0,extended,02000005
+patch=1,EE,11FF1A64,extended,00004268
+patch=1,EE,11FF1AC6,extended,00003A98
+//arcade race
+patch=1,EE,D0350AF0,extended,02000006
+patch=1,EE,11FBB990,extended,00004268
+patch=1,EE,11FBB9F2,extended,00003A98
+//arcade time trial
+patch=1,EE,D0350AF0,extended,02000007
+patch=1,EE,11FBB95C,extended,00004268
+patch=1,EE,11FBB9BE,extended,00003A98
+//
+
+[RPM Limits\32000 RPM (READ DESCRIPTION, Altered New Method)]
+author=Ooper,DopplerEffect
+description=Player Car Max RPM 32000. Begin race within 3 seconds. If you do not, enter settings menu and reenter. In modes without settings menu available, exit to menu and reload.
+//
+//race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial.
+//Test byte changed at 258 ticks for stability
+patch=1,EE,D1F978FC,extended,01000102
+patch=1,EE,00350AF0,extended,00000001
+patch=1,EE,D1F9685C,extended,01000102
+patch=1,EE,00350AF0,extended,00000002
+patch=1,EE,D1FD0D0C,extended,01000102
+patch=1,EE,00350AF0,extended,00000003
+patch=1,EE,D1FB728C,extended,01000102
+patch=1,EE,00350AF0,extended,00000004
+patch=1,EE,D1FC55BC,extended,01000102
+patch=1,EE,00350AF0,extended,00000005
+patch=1,EE,D1FAC35C,extended,01000102
+patch=1,EE,00350AF0,extended,00000006
+patch=1,EE,D1FBB6B0,extended,01000102
+patch=1,EE,00350AF0,extended,00000007
+//
+//Rev Limit set to 32000 RPM, Redline set to 28000 RPM
+//Sim Single Race
+patch=1,EE,D0350AF0,extended,02000001
+patch=1,EE,11FBDAB0,extended,00007D00
+patch=1,EE,11FBDB12,extended,00006D60
+//Sim Championship Race
+//Extra condition to reset rev limit and redline to 170000 RPM before next race for stability
+patch=1,EE,D0350AF0,extended,03000002
+patch=1,EE,11FBCA6C,extended,00007D00
+patch=1,EE,11FBCACE,extended,00006D60
+patch=1,EE,D1F9685C,extended,02200050
+patch=1,EE,11FBCA6C,extended,00004268
 patch=1,EE,11FBCACE,extended,00004268
+//Sim License Test
+patch=1,EE,D0350AF0,extended,02000003
+patch=1,EE,11FF1650,extended,00007D00
+patch=1,EE,11FF16B2,extended,00006D60
+//Sim Machine Test
+patch=1,EE,D0350AF0,extended,02000004
+patch=1,EE,11FF1900,extended,00007D00
+patch=1,EE,11FF1962,extended,00006D60
+//Sim Test Run
+patch=1,EE,D0350AF0,extended,02000005
+patch=1,EE,11FF1A64,extended,00007D00
+patch=1,EE,11FF1AC6,extended,00006D60
+//Arcade Race
+patch=1,EE,D0350AF0,extended,02000006
+patch=1,EE,11FBB990,extended,00007D00
+patch=1,EE,11FBB9F2,extended,00006D60
+//Arcade Time Trial
+patch=1,EE,D0350AF0,extended,02000007
+patch=1,EE,11FBB95C,extended,00007D00
+patch=1,EE,11FBB9BE,extended,00006D60
 
 [Gear Ratio\Normal]
 author=Ooper

--- a/8AA991B0.pnach
+++ b/8AA991B0.pnach
@@ -332,7 +332,7 @@ patch=1,EE,21FF1D4C,extended,3fa70a3c
 author=Ooper,DopplerEffect
 description=Player Car Max RPM 17000
 //race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial
-patch=1,EE,D1FFF1A4,extended,16000001 //If main menu value is 1...
+patch=1,EE,D1FFF1A4,extended,19000001 //If main menu value is 1...
 patch=1,EE,21F978FC,extended,00000000 //Set physics ticks to 0
 patch=1,EE,21F9685C,extended,00000000
 patch=1,EE,21FD0D0C,extended,00000000
@@ -340,6 +340,7 @@ patch=1,EE,21FB728C,extended,00000000
 patch=1,EE,21FC55BC,extended,00000000
 patch=1,EE,21FAC35C,extended,00000000
 patch=1,EE,21FBB6B0,extended,00000000
+patch=1,EE,21FC9A48,extended,00000000
 patch=1,EE,11FBDAB0,extended,00000000 //Set physics rpm/redline to 0
 patch=1,EE,11FBDB12,extended,00000000
 patch=1,EE,11FBCA6C,extended,00000000
@@ -354,6 +355,8 @@ patch=1,EE,11FBB990,extended,00000000
 patch=1,EE,11FBB9F2,extended,00000000
 patch=1,EE,11FBB95C,extended,00000000
 patch=1,EE,11FBB9BE,extended,00000000
+patch=1,EE,11FBB964,extended,00000000
+patch=1,EE,11FBB9C6,extended,00000000
 patch=1,EE,00350AF0,extended,0000000F //set test value to F
 
 //main menu value is 0 in races, so we need a second condition
@@ -367,20 +370,22 @@ patch=1,EE,E001000E,extended,00350AF0 //and test value is E
 patch=1,EE,00350AF0,extended,00000001 //set byte for sim single race
 patch=1,EE,E0020001,extended,01F9685C
 patch=1,EE,E001000E,extended,00350AF0
-patch=1,EE,00350AF0,extended,00000002
+patch=1,EE,00350AF0,extended,00000002 //set byte for championship race
 patch=1,EE,E0020001,extended,01FD0D0C
 patch=1,EE,E001000E,extended,00350AF0
-patch=1,EE,00350AF0,extended,00000003
+patch=1,EE,00350AF0,extended,00000003 //set byte for license test
 patch=1,EE,E0020001,extended,01FB728C
 patch=1,EE,E001000E,extended,00350AF0
-patch=1,EE,00350AF0,extended,00000004
+patch=1,EE,00350AF0,extended,00000004 //set byte for machine test
 patch=1,EE,E0020001,extended,01FC55BC
 patch=1,EE,E001000E,extended,00350AF0
-patch=1,EE,00350AF0,extended,00000005
-patch=1,EE,D1FAC35C,extended,01000001
-patch=1,EE,00350AF0,extended,00000006
-patch=1,EE,D1FBB6B0,extended,01000100
-patch=1,EE,00350AF0,extended,00000007
+patch=1,EE,00350AF0,extended,00000005 //set byte for test run
+patch=1,EE,D1FAC35C,extended,01000001 //if physics ticks hit 1
+patch=1,EE,00350AF0,extended,00000006 //set byte for arcade race
+patch=1,EE,D1FBB6B0,extended,01000100 //if physics ticks hit 0x0100
+patch=1,EE,00350AF0,extended,00000007 //set byte for time trial
+patch=1,EE,D1FC9A48,extended,01308000 //if physics ticks > 0x8000 (for some reason free run ticks up way faster)
+patch=1,EE,00350AF0,extended,00000008 //set byte for free run
 
 //sets rev limit to 17000 and redline to 15000
 patch=1,EE,D0350AF0,extended,02000001 //sim single race
@@ -404,14 +409,15 @@ patch=1,EE,11FBB9F2,extended,00003A98
 patch=1,EE,D0350AF0,extended,02000007 //arcade time trial
 patch=1,EE,11FBB95C,extended,00004268
 patch=1,EE,11FBB9BE,extended,00003A98
-//
+patch=1,EE,D0350AF0,extended,02000008 //arcade free run
+patch=1,EE,11FBB964,extended,00004268
+patch=1,EE,11FBB9C6,extended,00003A98
 
 [RPM Limits\32000 RPM (Stable In Simulation Mode)]
 author=Ooper,DopplerEffect
 description=Player Car Max RPM 32000. 3 seconds to hit "start race"
 //race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial
-patch=1,EE,D1FFF1A4,extended,16000001 //If main menu value is 1...
-patch=1,EE,01FBC240,extended,00000000 //Set championship stability value to 0
+patch=1,EE,D1FFF1A4,extended,19000001 //If main menu value is 1...
 patch=1,EE,21F978FC,extended,00000000 //Set physics ticks to 0
 patch=1,EE,21F9685C,extended,00000000
 patch=1,EE,21FD0D0C,extended,00000000
@@ -419,6 +425,7 @@ patch=1,EE,21FB728C,extended,00000000
 patch=1,EE,21FC55BC,extended,00000000
 patch=1,EE,21FAC35C,extended,00000000
 patch=1,EE,21FBB6B0,extended,00000000
+patch=1,EE,21FC9A48,extended,00000000
 patch=1,EE,11FBDAB0,extended,00000000 //Set physics rpm/redline to 0
 patch=1,EE,11FBDB12,extended,00000000
 patch=1,EE,11FBCA6C,extended,00000000
@@ -433,7 +440,10 @@ patch=1,EE,11FBB990,extended,00000000
 patch=1,EE,11FBB9F2,extended,00000000
 patch=1,EE,11FBB95C,extended,00000000
 patch=1,EE,11FBB9BE,extended,00000000
+patch=1,EE,11FBB964,extended,00000000
+patch=1,EE,11FBB9C6,extended,00000000
 patch=1,EE,00350AF0,extended,0000000F //set test value to F
+
 patch=1,EE,E0020000,extended,01FFF1A4 //If main menu value is 0... 
 patch=1,EE,E001000F,extended,00350AF0 //and test value is F...
 patch=1,EE,00350AF0,extended,0000000E //set test value to E
@@ -460,6 +470,8 @@ patch=1,EE,D1FAC35C,extended,01000102 //arcade race
 patch=1,EE,00350AF0,extended,00000006
 patch=1,EE,D1FBB6B0,extended,01000102 //arcade time trial
 patch=1,EE,00350AF0,extended,00000007
+patch=1,EE,D1FC9A48,extended,01008000 //arcade free run
+patch=1,EE,00350AF0,extended,00000008
 
 //sets rev limit to 32000 and redline to 28000
 patch=1,EE,D0350AF0,extended,02000001 //sim single race
@@ -483,6 +495,9 @@ patch=1,EE,11FBB9F2,extended,00006D60
 patch=1,EE,D0350AF0,extended,02000007 //arcade time trial
 patch=1,EE,11FBB95C,extended,00007D00
 patch=1,EE,11FBB9BE,extended,00006D60
+patch=1,EE,D0350AF0,extended,02000008 //arcade free run
+patch=1,EE,11FBB964,extended,00007D00
+patch=1,EE,11FBB9C6,extended,00006D60
 
 //end of championship race stability
 patch=1,EE,D1FBC240,extended,03000001 //if the replay has started

--- a/8AA991B0.pnach
+++ b/8AA991B0.pnach
@@ -312,12 +312,16 @@ patch=1,EE,D1FF2934,extended,02000001
 patch=1,EE,21FF1830,extended,3fa70a3c
 patch=1,EE,21FF1D4C,extended,3fa70a3c
 
+
 [License Tests\Normal Kerbs]
 author=Ooper
 description=Returns Kerbs back to normal.
 patch=1,EE,21FF1D4C,extended,3fa70a3c
 
+gametitle=Gran Turismo 3 [PBPX_955.03;1]NTSC [8AA991B0]
+
 //0350AF0 unused byte used for conditional execution
+//Main Menu Byte 1FFF1A4. Sets all values to safe values when it is 1. It is 1 before selecting an event and in main menu, so it will always reset values going from sim to arcade.
 //Single race ticks 1F978FC
 //Championship race ticks 1F9685C
 //License test ticks 1FD0D0C
@@ -325,110 +329,168 @@ patch=1,EE,21FF1D4C,extended,3fa70a3c
 //Home -> test run ticks 1FC55BC
 //Arcade Race Ticks 1FAC35C
 //Time Trial Ticks 1FBB6B0
+
 [RPM Limits\17000 RPM]
 author=Ooper,DopplerEffect
 description=Player Car Max RPM 17000
 //race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial
-patch=1,EE,D1F978FC,extended,01000001
-patch=1,EE,00350AF0,extended,00000001
-patch=1,EE,D1F9685C,extended,01000001
+patch=1,EE,D1FFF1A4,extended,16000001 //If main menu value is 1...
+patch=1,EE,21F978FC,extended,00000000 //Set physics ticks to 0
+patch=1,EE,21F9685C,extended,00000000
+patch=1,EE,21FD0D0C,extended,00000000
+patch=1,EE,21FB728C,extended,00000000
+patch=1,EE,21FC55BC,extended,00000000
+patch=1,EE,21FAC35C,extended,00000000
+patch=1,EE,21FBB6B0,extended,00000000
+patch=1,EE,11FBDAB0,extended,00000000 //Set physics rpm/redline to 0
+patch=1,EE,11FBDB12,extended,00000000
+patch=1,EE,11FBCA6C,extended,00000000
+patch=1,EE,11FBCACE,extended,00000000
+patch=1,EE,11FF1650,extended,00000000
+patch=1,EE,11FF16B2,extended,00000000
+patch=1,EE,11FF1900,extended,00000000
+patch=1,EE,11FF1962,extended,00000000
+patch=1,EE,11FF1A64,extended,00000000
+patch=1,EE,11FF1AC6,extended,00000000
+patch=1,EE,11FBB990,extended,00000000
+patch=1,EE,11FBB9F2,extended,00000000
+patch=1,EE,11FBB95C,extended,00000000
+patch=1,EE,11FBB9BE,extended,00000000
+patch=1,EE,00350AF0,extended,0000000F //set test value to F
+//main menu value is 0 in races, so we need a second condition
+patch=1,EE,E0020000,extended,01FFF1A4 //If main menu value is 0... 
+patch=1,EE,E001000F,extended,00350AF0 //and test value is F...
+patch=1,EE,00350AF0,extended,0000000E //set test value to E
+//if ticks value hits 1 and test value is E, change byte
+//This can only happen after we have reset the values safely when our byte was F
+patch=1,EE,E0020001,extended,01F978FC //if ticks value hits 1...
+patch=1,EE,E001000E,extended,00350AF0 //and test value is E
+patch=1,EE,00350AF0,extended,00000001 //set byte for sim single race
+patch=1,EE,E0020001,extended,01F9685C
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000002
-patch=1,EE,D1FD0D0C,extended,01000001
+patch=1,EE,E0020001,extended,01FD0D0C
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000003
-patch=1,EE,D1FB728C,extended,01000001
+patch=1,EE,E0020001,extended,01FB728C
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000004
-patch=1,EE,D1FC55BC,extended,01000001
+patch=1,EE,E0020001,extended,01FC55BC
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000005
 patch=1,EE,D1FAC35C,extended,01000001
 patch=1,EE,00350AF0,extended,00000006
 patch=1,EE,D1FBB6B0,extended,01000100
 patch=1,EE,00350AF0,extended,00000007
+
 //sets rev limit to 17000 and redline to 15000
-//sim single race
-patch=1,EE,D0350AF0,extended,02000001
+patch=1,EE,D0350AF0,extended,02000001 //sim single race
 patch=1,EE,11FBDAB0,extended,00004268
 patch=1,EE,11FBDB12,extended,00003A98
-//sim championship race
-patch=1,EE,D0350AF0,extended,02000002
+patch=1,EE,D0350AF0,extended,02000002 //sim championship race
 patch=1,EE,11FBCA6C,extended,00004268
 patch=1,EE,11FBCACE,extended,00003A98
-//sim license test
-patch=1,EE,D0350AF0,extended,02000003
+patch=1,EE,D0350AF0,extended,02000003 //sim license test
 patch=1,EE,11FF1650,extended,00004268
 patch=1,EE,11FF16B2,extended,00003A98
-//sim machine test
-patch=1,EE,D0350AF0,extended,02000004
+patch=1,EE,D0350AF0,extended,02000004 //sim machine test
 patch=1,EE,11FF1900,extended,00004268
 patch=1,EE,11FF1962,extended,00003A98
-//sim test run
-patch=1,EE,D0350AF0,extended,02000005
+patch=1,EE,D0350AF0,extended,02000005 //sim test run
 patch=1,EE,11FF1A64,extended,00004268
 patch=1,EE,11FF1AC6,extended,00003A98
-//arcade race
-patch=1,EE,D0350AF0,extended,02000006
+patch=1,EE,D0350AF0,extended,02000006 //arcade race
 patch=1,EE,11FBB990,extended,00004268
 patch=1,EE,11FBB9F2,extended,00003A98
-//arcade time trial
-patch=1,EE,D0350AF0,extended,02000007
+patch=1,EE,D0350AF0,extended,02000007 //arcade time trial
 patch=1,EE,11FBB95C,extended,00004268
 patch=1,EE,11FBB9BE,extended,00003A98
 //
 
-[RPM Limits\32000 RPM (READ DESCRIPTION, Altered New Method)]
+[RPM Limits\32000 RPM (Stable In Simulation Mode)]
 author=Ooper,DopplerEffect
-description=Player Car Max RPM 32000. Begin race within 3 seconds. If you do not, enter settings menu and reenter. In modes without settings menu available, exit to menu and reload.
-//
-//race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial.
-//Test byte changed at 258 ticks for stability
-patch=1,EE,D1F978FC,extended,01000102
+description=Player Car Max RPM 32000. 3 seconds to hit "start race"
+//race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial
+patch=1,EE,D1FFF1A4,extended,16000001 //If main menu value is 1...
+patch=1,EE,21F978FC,extended,00000000 //Set physics ticks to 0
+patch=1,EE,21F9685C,extended,00000000
+patch=1,EE,21FD0D0C,extended,00000000
+patch=1,EE,21FB728C,extended,00000000
+patch=1,EE,21FC55BC,extended,00000000
+patch=1,EE,21FAC35C,extended,00000000
+patch=1,EE,21FBB6B0,extended,00000000
+patch=1,EE,11FBDAB0,extended,00000000 //Set physics rpm/redline to 0
+patch=1,EE,11FBDB12,extended,00000000
+patch=1,EE,11FBCA6C,extended,00000000
+patch=1,EE,11FBCACE,extended,00000000
+patch=1,EE,11FF1650,extended,00000000
+patch=1,EE,11FF16B2,extended,00000000
+patch=1,EE,11FF1900,extended,00000000
+patch=1,EE,11FF1962,extended,00000000
+patch=1,EE,11FF1A64,extended,00000000
+patch=1,EE,11FF1AC6,extended,00000000
+patch=1,EE,11FBB990,extended,00000000
+patch=1,EE,11FBB9F2,extended,00000000
+patch=1,EE,11FBB95C,extended,00000000
+patch=1,EE,11FBB9BE,extended,00000000
+patch=1,EE,00350AF0,extended,0000000F //set test value to F
+patch=1,EE,E0020000,extended,01FFF1A4 //If main menu value is 0... 
+patch=1,EE,E001000F,extended,00350AF0 //and test value is F...
+patch=1,EE,00350AF0,extended,0000000E //set test value to E
+//main menu value is 0 in races, so we needed a second condition
+//if ticks value hits 0x0102 and test value is E, change byte
+//This can only happen after we have reset the values safely when our byte was F
+patch=1,EE,E0020102,extended,01F978FC //sim single race
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000001
-patch=1,EE,D1F9685C,extended,01000102
+patch=1,EE,E0020102,extended,01F9685C //sim championship race
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000002
-patch=1,EE,D1FD0D0C,extended,01000102
+patch=1,EE,E0020102,extended,01FD0D0C //sim licese test
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000003
-patch=1,EE,D1FB728C,extended,01000102
+patch=1,EE,E0020102,extended,01FB728C //sim machine test
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000004
-patch=1,EE,D1FC55BC,extended,01000102
+patch=1,EE,E0020102,extended,01FC55BC //sim test run
+patch=1,EE,E001000E,extended,00350AF0
 patch=1,EE,00350AF0,extended,00000005
-patch=1,EE,D1FAC35C,extended,01000102
+patch=1,EE,D1FAC35C,extended,01000102 //arcade race
 patch=1,EE,00350AF0,extended,00000006
-patch=1,EE,D1FBB6B0,extended,01000102
+patch=1,EE,D1FBB6B0,extended,01000102 //arcade time trial
 patch=1,EE,00350AF0,extended,00000007
-//
-//Rev Limit set to 32000 RPM, Redline set to 28000 RPM
-//Sim Single Race
-patch=1,EE,D0350AF0,extended,02000001
+
+//sets rev limit to 32000 and redline to 28000
+patch=1,EE,D0350AF0,extended,02000001 //sim single race
 patch=1,EE,11FBDAB0,extended,00007D00
 patch=1,EE,11FBDB12,extended,00006D60
-//Sim Championship Race
-//Extra condition to reset rev limit and redline to 170000 RPM before next race for stability
-patch=1,EE,D0350AF0,extended,03000002
+patch=1,EE,D0350AF0,extended,02000002 //sim championship race
 patch=1,EE,11FBCA6C,extended,00007D00
 patch=1,EE,11FBCACE,extended,00006D60
-patch=1,EE,D1F9685C,extended,02200050
-patch=1,EE,11FBCA6C,extended,00004268
-patch=1,EE,11FBCACE,extended,00004268
-//Sim License Test
-patch=1,EE,D0350AF0,extended,02000003
+patch=1,EE,D0350AF0,extended,02000003 //sim license test
 patch=1,EE,11FF1650,extended,00007D00
 patch=1,EE,11FF16B2,extended,00006D60
-//Sim Machine Test
-patch=1,EE,D0350AF0,extended,02000004
+patch=1,EE,D0350AF0,extended,02000004 //sim machine test
 patch=1,EE,11FF1900,extended,00007D00
 patch=1,EE,11FF1962,extended,00006D60
-//Sim Test Run
-patch=1,EE,D0350AF0,extended,02000005
+patch=1,EE,D0350AF0,extended,02000005 //sim test run
 patch=1,EE,11FF1A64,extended,00007D00
 patch=1,EE,11FF1AC6,extended,00006D60
-//Arcade Race
-patch=1,EE,D0350AF0,extended,02000006
+patch=1,EE,D0350AF0,extended,02000006 //arcade race
 patch=1,EE,11FBB990,extended,00007D00
 patch=1,EE,11FBB9F2,extended,00006D60
-//Arcade Time Trial
-patch=1,EE,D0350AF0,extended,02000007
+patch=1,EE,D0350AF0,extended,02000007 //arcade time trial
 patch=1,EE,11FBB95C,extended,00007D00
 patch=1,EE,11FBB9BE,extended,00006D60
 
+//end of championship race stability
+patch=1,EE,D1FBC240,extended,03000001 //if the replay has started
+patch=1,EE,00350AF0,extended,0000000A //set our value to A
+patch=1,EE,11FBCA6C,extended,00001000 //set rpm and redline to 0x1000
+patch=1,EE,11FBCACE,extended,00001000
+patch=1,EE,E0020102,extended,01F9685C //If physics ticks hits 0x0102...
+patch=1,EE,E001000A,extended,00350AF0 //and the value is A...
+patch=1,EE,00350AF0,extended,00000002 //set our value to 2
 [Gear Ratio\Normal]
 author=Ooper
 description=Set global gear ratio scale to normal value

--- a/8AA991B0.pnach
+++ b/8AA991B0.pnach
@@ -355,11 +355,12 @@ patch=1,EE,11FBB9F2,extended,00000000
 patch=1,EE,11FBB95C,extended,00000000
 patch=1,EE,11FBB9BE,extended,00000000
 patch=1,EE,00350AF0,extended,0000000F //set test value to F
+
 //main menu value is 0 in races, so we need a second condition
 patch=1,EE,E0020000,extended,01FFF1A4 //If main menu value is 0... 
 patch=1,EE,E001000F,extended,00350AF0 //and test value is F...
 patch=1,EE,00350AF0,extended,0000000E //set test value to E
-//if ticks value hits 1 and test value is E, change byte
+
 //This can only happen after we have reset the values safely when our byte was F
 patch=1,EE,E0020001,extended,01F978FC //if ticks value hits 1...
 patch=1,EE,E001000E,extended,00350AF0 //and test value is E
@@ -436,6 +437,7 @@ patch=1,EE,E0020000,extended,01FFF1A4 //If main menu value is 0...
 patch=1,EE,E001000F,extended,00350AF0 //and test value is F...
 patch=1,EE,00350AF0,extended,0000000E //set test value to E
 //main menu value is 0 in races, so we needed a second condition
+
 //if ticks value hits 0x0102 and test value is E, change byte
 //This can only happen after we have reset the values safely when our byte was F
 patch=1,EE,E0020102,extended,01F978FC //sim single race
@@ -489,6 +491,7 @@ patch=1,EE,11FBCACE,extended,00001000
 patch=1,EE,E0020102,extended,01F9685C //If physics ticks hits 0x0102...
 patch=1,EE,E001000A,extended,00350AF0 //and the value is A...
 patch=1,EE,00350AF0,extended,00000002 //set our value to 2
+
 [Gear Ratio\Normal]
 author=Ooper
 description=Set global gear ratio scale to normal value

--- a/8AA991B0.pnach
+++ b/8AA991B0.pnach
@@ -411,6 +411,7 @@ author=Ooper,DopplerEffect
 description=Player Car Max RPM 32000. 3 seconds to hit "start race"
 //race selection in the following order: sim single, sim champ, sim license, sim machine test, sim test run, arcade race, arcade time trial
 patch=1,EE,D1FFF1A4,extended,16000001 //If main menu value is 1...
+patch=1,EE,01FBC240,extended,00000000 //Set championship stability value to 0
 patch=1,EE,21F978FC,extended,00000000 //Set physics ticks to 0
 patch=1,EE,21F9685C,extended,00000000
 patch=1,EE,21FD0D0C,extended,00000000


### PR DESCRIPTION
Modified the 17000 RPM patch to behave in a more stable way. All RPM and redline values will be reset when returning to race selection and between championship races.

This was done with flow control with E-type codes instead of D-type, as the former allows for conditional if statements, as there are a few "if X && Y" type statements in there. I uses 1FFF1A4 to determine when a race is about to start in simulation or if the main menu between sim and arcade is accessed. I also used 1FBC240 to determine when the replay has started after a championship race, and it will reset the appropriate values if needed.

This has made the 32000 RPM patch relatively stable with the only caveat being that you must start a race in simulation within 3 seconds of the race preview screen appearing. apart from that, it is safe and stable between events in sim and has not resulted in a crash after 2 hours of testing.